### PR TITLE
Feat: Add Sigle History Delete #9

### DIFF
--- a/src/components/Queries/QueryHistory.js
+++ b/src/components/Queries/QueryHistory.js
@@ -6,6 +6,7 @@ import {
   Heading,
   HStack,
   IconButton,
+  Flex,
 } from "@chakra-ui/react";
 import { BsCodeSquare } from "react-icons/bs";
 import { MdDelete } from "react-icons/md";
@@ -15,6 +16,9 @@ function QueryHistory({ history, setQuery, setValue, setHistory }) {
     if (value.includes("*")) setQuery(value);
     setValue(value);
   };
+  const handleRemoveHistory = (historyItem) => {
+    setHistory(prevHistory => prevHistory.filter(history => history !== historyItem));
+  }
   return (
     <Box
       w={["100%", "20%"]}
@@ -47,8 +51,15 @@ function QueryHistory({ history, setQuery, setValue, setHistory }) {
               cursor={"pointer"}
               _hover={{ bg: "teal.500" }}
             >
-              <ListIcon as={BsCodeSquare} />
-              {item}
+              <Flex>
+                <ListIcon as={BsCodeSquare} />
+                {item}
+                <IconButton
+                  icon={<MdDelete />}
+                  aria-label="Delete"
+                  onClick={() => handleRemoveHistory(item)}
+                ></IconButton>
+              </Flex>
             </ListItem>
           ))}
         </List>

--- a/src/components/Queries/QueryHistory.js
+++ b/src/components/Queries/QueryHistory.js
@@ -16,7 +16,8 @@ function QueryHistory({ history, setQuery, setValue, setHistory }) {
     if (value.includes("*")) setQuery(value);
     setValue(value);
   };
-  const handleRemoveHistory = (historyItem) => {
+  const handleRemoveHistory = (e, historyItem) => {
+    e.stopPropagation();
     setHistory(prevHistory => prevHistory.filter(history => history !== historyItem));
   }
   return (
@@ -57,7 +58,7 @@ function QueryHistory({ history, setQuery, setValue, setHistory }) {
                 <IconButton
                   icon={<MdDelete />}
                   aria-label="Delete"
-                  onClick={() => handleRemoveHistory(item)}
+                  onClick={(e) => handleRemoveHistory(e, item)}
                 ></IconButton>
               </Flex>
             </ListItem>


### PR DESCRIPTION
**Description**

- When we click on the Delete icon, we filter out the History State and update the state with all other history other than the current history item.
- Please review the code. I've updated some UI in the History List because the Delete button was moving to the other line. Please let me know about this
The video is attached below

https://github.com/janvi01/sql-editor/assets/50802786/a01dbe0f-18bd-481b-8b3d-41797e212692


**Related issue(s)**
Fixes #9 