### PR TITLE
Fix to results not loading when user runs the query 2nd time

### DIFF
--- a/src/pages/FrontLayout.js
+++ b/src/pages/FrontLayout.js
@@ -19,7 +19,7 @@ const FrontLayout = () => {
 
   const runQuery = () => {
     setSubmittedQuery(query);
-    setLoading(!loading);
+    setLoading(false);
   };
 
   return (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- Initially, on running query setLoading was set to '!loading'. loading is set to true in the beginning. When user ran the query first time, loading was set to '!loading (false) and results were displayed. When user ran the query 2nd time, it was set to !loading again (true in this case as it was false earlier). So it wasn't displaying results. 

- With new changes, loading state will always be set to false on running the query.

**Related issue(s)**
#28 