### PR TITLE
feat: added toast for run succesfull query

### DIFF
--- a/src/components/Output/OutputDisplay.js
+++ b/src/components/Output/OutputDisplay.js
@@ -10,6 +10,7 @@ import {
   VStack,
   Stack,
   HStack,
+  useToast, // Import useToast
 } from "@chakra-ui/react";
 import { queryMap } from "../../assets/data/queries";
 import CsvDownload from "react-json-to-csv";
@@ -20,6 +21,7 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
   const [results, setResults] = useState([]);
   const [filename, setFilename] = useState("");
   const [queryTime, setQueryTime] = useState();
+  const toast = useToast(); // Initialize useToast
 
   useEffect(() => {
     // loading result and fetching query time
@@ -28,6 +30,16 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
     setLoading(false);
     let endTime = performance.now();
     setQueryTime((endTime - startTime).toFixed(2) + " ms");
+
+    // Show toast when query runs successfully
+    toast({
+      title: "Query Run Successfully",
+      description: "Your query has been executed successfully.",
+      status: "success",
+      duration: 2000, 
+      isClosable: true,
+      colorScheme: "blue",
+    });
     // eslint-disable-next-line
   }, [submittedQuery]);
 
@@ -107,7 +119,7 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
           <Heading as="h1" fontSize="xl" mt={4}>
             Nothing to show at the moment
           </Heading>
-          <Text>Run a query first to see resulting tablet</Text>
+          <Text>Run a query first to see resulting table</Text>
         </VStack>
       )}
     </>


### PR DESCRIPTION

**Description**

- Added toast to show query successful run after loading

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. --> feat #37 