### PR TITLE
Fixes: Query history delete button visibility On Query History has history #49

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -46,7 +46,10 @@ const Editor = ({
 
   const SubmitQuery = () => {
     runQuery();
-    setHistory([...history, value]);
+    if (history.length === 0 || history[history.length - 1] !== value) {
+    // If not, add it to history
+    setHistory((prevHistory) => [...prevHistory,value]);
+}
   };
 
   const errorQuery = () => {

--- a/src/components/Queries/QueryHistory.js
+++ b/src/components/Queries/QueryHistory.js
@@ -41,6 +41,7 @@ function QueryHistory({ history, setQuery, setValue, setHistory }) {
         <IconButton
           icon={<MdDelete />}
           aria-label="Delete"
+          visibility={history.length === 0 ? "hidden" : "visible"}
           onClick={() => setHistory([])}
         ></IconButton>
       </HStack>


### PR DESCRIPTION
**Description**

- If query History has no history the delete all history button should be hidden.
- once query history has elements, query history delete button is visible.
- ...

**Related issue(s)**
Resovles #49 