### PR TITLE
fixes #51: Display recently executed query at the top of the history

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -46,10 +46,10 @@ const Editor = ({
 
   const SubmitQuery = () => {
     runQuery();
-    if (history.length === 0 || history[history.length - 1] !== value) {
+    if (history.length === 0 || history[0] !== value) {
     // If not, add it to history
-    setHistory((prevHistory) => [...prevHistory,value]);
-}
+    setHistory((prevHistory) => [value,...prevHistory]);
+    }
   };
 
   const errorQuery = () => {


### PR DESCRIPTION
**Summary**
This pull request addresses the issue where the recently executed query is appended to the end of the query history instead of being displayed at the top. The fix ensures that the most recent query is now positioned at the top of the query history.

**Changes Made**
Modified the logic for updating the query history to place the most recent query at the beginning of the array.

**Related Issue**
Closes #51