### PR TITLE
fix bug: recent queries should be at the top of query history

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -47,9 +47,9 @@ const Editor = ({
   const SubmitQuery = () => {
     runQuery();
     if (history.length === 0 || history[history.length - 1] !== value) {
-    // If not, add it to history
-    setHistory((prevHistory) => [...prevHistory,value]);
-}
+      // If not, add it to history
+      setHistory((prevHistory) => [value, ...prevHistory]);
+    }
   };
 
   const errorQuery = () => {


### PR DESCRIPTION
Describe the bug
The recently executed query is appended to the end of the query history, which should be displayed at the top instead of the last position in the query history.

To Reproduce
-Execute a query.
-Execute another query.
-Observe the position of the last executed query in the query history.

Expected behavior
The recently executed query should be displayed at the top of the query history.

Screenshots

https://github.com/janvi01/sql-editor/assets/80145855/f3665412-ef69-4370-a916-441776c25b0f

Fixes #51 


