### PR TITLE
feat: Add functionality to display and track the number of rows affected

### DIFF
--- a/src/components/Output/OutputDisplay.js
+++ b/src/components/Output/OutputDisplay.js
@@ -21,6 +21,7 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
   const [results, setResults] = useState([]);
   const [filename, setFilename] = useState("");
   const [queryTime, setQueryTime] = useState();
+  const [rowsAffected, setRowsAffected] = useState(0);
   const toast = useToast();
 
   useEffect(() => {
@@ -48,14 +49,18 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
   const selectResults = () => {
     if (submittedQuery === "") {
       setResults([]);
+      setRowsAffected(0);
       return;
     }
     const queryIndex = queryMap.findIndex((o) => o.query === submittedQuery);
     if (queryIndex === -1) {
       setResults([]);
+      setRowsAffected(0);
     } else {
-      setResults(queryMap[queryIndex].data);
-      setFilename(queryMap[queryIndex].tableQuery);
+        const queryData = queryMap[queryIndex].data;
+        setResults(queryData);
+        setFilename(queryMap[queryIndex].tableQuery);
+        setRowsAffected(queryData.length);
     }
   };
 
@@ -94,6 +99,9 @@ const OutputDisplay = ({ submittedQuery, loading, setLoading }) => {
               align={"center"}
               direction={["column-reverse", "row"]}
             >
+              <Button colorScheme="blue" mr={2} cursor={"initial"} size={"xs"}>
+                Rows Affected: {rowsAffected}
+              </Button>
               <Button colorScheme="blue" mr={2} cursor={"initial"} size={"xs"}>
                 Query took: {queryTime}
               </Button>


### PR DESCRIPTION
## Changes Made:

- Introduce a new state variable rowsAffected to store the count of rows affected by the query.

## Purpose:
This pull request enhances the OutputDisplay component by providing users with information on the number of rows affected by the executed query. The introduction of the rowsAffected state variable and associated changes improve the clarity of the query output section.

## How to Test:

- Run the application.
- Execute a query using the OutputDisplay component.
- Observe the "Rows Affected" button to ensure it displays the correct count of rows impacted by the query.

closes #50 